### PR TITLE
Add some default community health files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+We love contribution from everyone!
+
+When contributing to this repo, please first discuss the change you wish to make via issue or discussion with the maintainers of this repository before making a change.
+
+## Issue
+
+All bug reports and feature requests happen through Issues. If you have any bugs for feature requests(no matter if you are a maintainer), please create a issue frist. Github Discussions is for questions and anything else.
+
+We leverage labels to categorize issues, so it's the repo maintainer's responsibility to add suitable label(s) for every issues.
+
+## Pull Request
+
+Pull Requests should follow the single responsibility principle and small Pull Requests are encouraged. Try not to include some additional stuff into the pull request. For example, do not fix any typos other than your current context or do not add a tiny bug fix to a feature.
+
+All code changes happen through Pull Requests. We actively welcome your pull requests:
+
+1. If you are a member of Alpensegler, clone the repo and create your branch from `master`. Or, fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've added code that need documentation, update the documentation.
+3. Write a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).
+5. Follow the template to issue a pull request.
+
+Labels are optional but encouraged for Pull Requests.
+

--- a/ISSUE_TEMPLATE/bug_report.yml
+++ b/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,23 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["type/bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+    validations:
+      required: true
+  - type: textarea
+    id: extra-info
+    attributes:
+      label: Extra Information
+      description: Please provide the current system version, framework version and other helpful information.
+

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+

--- a/ISSUE_TEMPLATE/feature_request.yml
+++ b/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,12 @@
+name: Feature Request
+description: Suggest an idea or ask for a feature
+title: "[Feature Request]: "
+labels: ["type/feature-request"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What's your idea or suggestion?
+    validations:
+      required: true
+

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/Alpensegler/.github//blob/master/CONTRIBUTING.md) guide
+- [ ] I added a very descriptive title to this pull request
+- [ ] I have follow the [guide](https://www.conventionalcommits.org/en/v1.0.0/) to write commit messages
+
+## Additional Information
+
+Describe any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc
+


### PR DESCRIPTION
Github supports creates default community health files for all repos in the same organization or personal account:
[Creating a default community health file - GitHub Docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)
[How to Use the .github Repository](https://www.freecodecamp.org/news/how-to-use-the-dot-github-repository/)

So This PR paves the foundations for maintaining repos in Alpensegler by adding:

1. CONTRIBUTING: how people should contribute to your project
2. Issue templates for bug report and feature request
3. pull request template