### PR TITLE
fix: remove trailing new line in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,3 @@ Describe the big picture of your changes here to communicate to the maintainers 
 ## Additional Information
 
 Describe any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc
-


### PR DESCRIPTION
## Description

This PR removes the redundant trailing new line in pr template as we don't need so much spacing when writing PR description.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Alpensegler/.github//blob/master/CONTRIBUTING.md) guide
- [x] I added a very descriptive title to this pull request
- [x] I have follow the [guide](https://www.conventionalcommits.org/en/v1.0.0/) to write commit messages