### PR TITLE
improve: adopt squash merge policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,7 @@
 ## Description
+<!--- Describe your changes in detail -->
 
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-
-## Checklist
-
-- [ ] I have read the [CONTRIBUTING](https://github.com/Alpensegler/.github//blob/master/CONTRIBUTING.md) guide
-- [ ] I added a very descriptive title to this pull request
-- [ ] I have follow the [guide](https://www.conventionalcommits.org/en/v1.0.0/) to write commit messages
-
-## Additional Information
-
-Describe any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc
+## Issue Link
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
+<!--- Please link to the issue here: -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ All code changes happen through Pull Requests. We actively welcome your pull req
 1. If you are a member of Alpensegler, clone the repo and create your branch from `master`. Or, fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests.
 3. If you've added code that need documentation, update the documentation.
-3. Write a [conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).
-5. Follow the template to issue a pull request.
+4. Follow the template to issue a pull request.
+5. Follow [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/) to write the pull request title.
 
 Labels are optional but encouraged for Pull Requests.
 


### PR DESCRIPTION
## Description

As discussed, we are going to change the PR merge policy from rebase to squash, the new merge policy will:
1. Let us focus on the changes rather than the commits themselves while still keeping the commit history for master branch succinct
2. Act as a soft force to let PR follow the single responsibility principle as described in the CONTRIBUTING.

So this PR:
1. Updates the CONTRIBUTING to reflect the merge policy change.
2. Simplifies the PR template as we will use PR title and description to generate the squashing commit's message by default(PR title will be checked automatically by Github Action).
  We're Also removing the checklist as some of them(PR title and commit message) are unnecessary for the new merge policy and GitHub will remind you to read CONTRIBUTING if you're making contribution to the repo for the first time.
